### PR TITLE
docs: Modify .gitignore node modules down repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+vscode
+public
+document
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?


### PR DESCRIPTION
# Cambios
- El archivo .gitignore se ignoran los modulos pesados y otras carpetas donde se puedan contar con ficheros muy grandes como log, las dependencias de los paquetes, las carpetas public, la carpeta de empaquetado dist  y carpetas de mac que se llegan a crear al tener el desarrollo activo
@AgsRobert08 
